### PR TITLE
Allow I2C pins to be configurable

### DIFF
--- a/Adafruit_CAP1188.cpp
+++ b/Adafruit_CAP1188.cpp
@@ -41,6 +41,8 @@ Adafruit_CAP1188::Adafruit_CAP1188(int8_t resetpin) {
   // I2C
   _resetpin = resetpin;
   _i2c = true;
+  _i2cdatapin = SDA;
+  _i2cclockpin = SCL;
 }
 
 Adafruit_CAP1188::Adafruit_CAP1188(int8_t cspin, int8_t resetpin) {
@@ -63,9 +65,14 @@ Adafruit_CAP1188::Adafruit_CAP1188(int8_t clkpin, int8_t misopin,
   _i2c = false;
 }
 
+void Adafruit_CAP1188::setI2CPins(int i2cclock, int i2cdata) {
+  _i2cdatapin = i2cdata;
+  _i2cclockpin = i2cclock;
+}
+
 boolean Adafruit_CAP1188::begin(uint8_t i2caddr) {
   if (_i2c) {
-    Wire.begin();
+    Wire.begin(_i2cdatapin, _i2cclockpin);
     
     _i2caddr = i2caddr;
   } else if (_clk == -1) {

--- a/Adafruit_CAP1188.h
+++ b/Adafruit_CAP1188.h
@@ -46,9 +46,10 @@ class Adafruit_CAP1188 {
 		   int8_t resetpin);
   // Hardware SPI
   Adafruit_CAP1188(int8_t cspin, int8_t resetpin);
-  // Hardware I2C
+  // Hardware I2C - default Arduino pins
   Adafruit_CAP1188(int8_t resetpin = -1);
 
+  void setI2CPins(int i2cclock, int i2cdata);
   boolean begin(uint8_t i2caddr = CAP1188_I2CADDR);
   uint8_t readRegister(uint8_t reg);
   void writeRegister(uint8_t reg, uint8_t value);
@@ -59,5 +60,6 @@ class Adafruit_CAP1188 {
   uint8_t spixfer(uint8_t x);
   boolean _i2c;
   int8_t _i2caddr, _resetpin, _cs, _clk, _mosi, _miso;
+  int _i2cdatapin, _i2cclockpin;
 };
 


### PR DESCRIPTION
This change allows the pins to be used for I2C to be configured. When using a real Arduino you don't want to do this, but if using the CAP1188 with something like an ESP8266 it is useful to be able to configure the pins.

As the constructor is already overloaded, I added a method setI2CPins(int i2cclock, int i2cdata). If you don't call this method, then it uses the default for Wire (SCL and SDA). If you do call this method, then it uses the pins you specified when configuring Wire.

