### PR TITLE
Interrupt sensor read fixed

### DIFF
--- a/Adafruit_CAP1188.cpp
+++ b/Adafruit_CAP1188.cpp
@@ -127,11 +127,11 @@ boolean Adafruit_CAP1188::begin(uint8_t i2caddr) {
 }
 
 uint8_t  Adafruit_CAP1188::touched(void) {
-  uint8_t t = readRegister(CAP1188_SENINPUTSTATUS);
-  if (t) {
-    writeRegister(CAP1188_MAIN, readRegister(CAP1188_MAIN) & ~CAP1188_MAIN_INT);
+  uint8_t temp = readRegister(CAP1XXX_MAIN);
+  if (temp & CAP1XXX_MAIN_INT) {
+  	writeRegister(CAP1XXX_MAIN, temp & ~CAP1XXX_MAIN_INT);
   }
-  return t;
+  return readRegister(CAP1XXX_SENINPUTSTATUS);
 }
 
 void Adafruit_CAP1188::LEDpolarity(uint8_t x) {

--- a/Adafruit_CAP1188.cpp
+++ b/Adafruit_CAP1188.cpp
@@ -127,11 +127,11 @@ boolean Adafruit_CAP1188::begin(uint8_t i2caddr) {
 }
 
 uint8_t  Adafruit_CAP1188::touched(void) {
-  uint8_t temp = readRegister(CAP1XXX_MAIN);
-  if (temp & CAP1XXX_MAIN_INT) {
-  	writeRegister(CAP1XXX_MAIN, temp & ~CAP1XXX_MAIN_INT);
+  uint8_t t = readRegister(CAP1188_MAIN);
+  if (t & CAP1188_MAIN_INT) {
+  	writeRegister(CAP1188_MAIN, t & ~CAP1188_MAIN_INT);
   }
-  return readRegister(CAP1XXX_SENINPUTSTATUS);
+  return readRegister(CAP1188_SENINPUTSTATUS);
 }
 
 void Adafruit_CAP1188::LEDpolarity(uint8_t x) {


### PR DESCRIPTION
I fixed the touched funcion to be able to read the actual value of the input when an interrupt occurred.
In the old version to read the actual value you had to call the function twice.