### PR TITLE
Missing pinMode for _cs in hardware SPI mode

### DIFF
--- a/Adafruit_CAP1188.cpp
+++ b/Adafruit_CAP1188.cpp
@@ -70,6 +70,7 @@ boolean Adafruit_CAP1188::begin(uint8_t i2caddr) {
     _i2caddr = i2caddr;
   } else if (_clk == -1) {
     // Hardware SPI
+    pinMode(_cs, OUTPUT);
     digitalWrite(_cs, HIGH);
 #ifdef SPI_HAS_TRANSACTION
       SPI.begin();


### PR DESCRIPTION
When operating in hardware SPI mode, the SPI slave is not responding because the CS signal is not properly driven. The library is not setting the `_cs` pin to output before calling `digitalWrite` on it. This PR just adds this one missing line.