### PR TITLE
Remove hardwired Serial output

### DIFF
--- a/Adafruit_CAP1188.cpp
+++ b/Adafruit_CAP1188.cpp
@@ -116,14 +116,14 @@ boolean Adafruit_CAP1188::begin(uint8_t i2caddr, TwoWire *theWire) {
 
   readRegister(CAP1188_PRODID);
 
-  // Useful debugging info
+  // Useful debugging info. Comment/uncomment as needed.
 
-  Serial.print("Product ID: 0x");
-  Serial.println(readRegister(CAP1188_PRODID), HEX);
-  Serial.print("Manuf. ID: 0x");
-  Serial.println(readRegister(CAP1188_MANUID), HEX);
-  Serial.print("Revision: 0x");
-  Serial.println(readRegister(CAP1188_REV), HEX);
+  // Serial.print("Product ID: 0x");
+  // Serial.println(readRegister(CAP1188_PRODID), HEX);
+  // Serial.print("Manuf. ID: 0x");
+  // Serial.println(readRegister(CAP1188_MANUID), HEX);
+  // Serial.print("Revision: 0x");
+  // Serial.println(readRegister(CAP1188_REV), HEX);
 
   if ((readRegister(CAP1188_PRODID) != 0x50) ||
       (readRegister(CAP1188_MANUID) != 0x5D) ||


### PR DESCRIPTION
For #13.

For now, just commenting out the `Serial.prints()`. In the long run, would be nice to add getters for these info registers and add the reading and printing to example sketch.

Tested on a QTPT RP2040 running `cap1188test.ino` example sketch from this library.

**BEFORE**
![Screenshot from 2025-01-23 11-14-37](https://github.com/user-attachments/assets/2b4e673a-d962-46cf-b400-668bfb736979)

**AFTER**
![Screenshot from 2025-01-23 11-15-29](https://github.com/user-attachments/assets/258dba77-95e0-49e0-ba24-d4ed5a980011)
